### PR TITLE
fix: filters [CHAIN-533]

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@fluencelabs/deal-ts-clients": "^0.13.11",
+    "@fluencelabs/deal-ts-clients": "^0.13.12",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-aspect-ratio": "^1.0.3",
     "@radix-ui/react-checkbox": "^1.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^11.11.0
         version: 11.11.0(@emotion/react@11.11.1(@types/react@18.2.25)(react@18.2.0))(@types/react@18.2.25)(react@18.2.0)
       '@fluencelabs/deal-ts-clients':
-        specifier: ^0.13.11
-        version: 0.13.11(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@6.0.3)
+        specifier: ^0.13.12
+        version: 0.13.12(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@6.0.3)
       '@radix-ui/react-accordion':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.2.10)(@types/react@18.2.25)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -1242,8 +1242,8 @@ packages:
   '@floating-ui/utils@0.1.6':
     resolution: {integrity: sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==}
 
-  '@fluencelabs/deal-ts-clients@0.13.11':
-    resolution: {integrity: sha512-miSvbgZRp+lPR+A9cI8Bzu/hhzkyIcscqAEdbMwBANsdC4GDkHTRJfw33s852bhBxHgrwS+gOwURaS03dtfiDg==}
+  '@fluencelabs/deal-ts-clients@0.13.12':
+    resolution: {integrity: sha512-2NSflGD8bkAaMCRj8gHz5XtEiRWJ2JyUsXYvjTYJh89GQzRFdTqENPzWSosezJabHY76aHVlx1vLbKQYig8Yvg==}
 
   '@graphql-typed-document-node/core@3.2.0':
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
@@ -7602,7 +7602,7 @@ snapshots:
 
   '@floating-ui/utils@0.1.6': {}
 
-  '@fluencelabs/deal-ts-clients@0.13.11(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@6.0.3)':
+  '@fluencelabs/deal-ts-clients@0.13.12(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@6.0.3)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.8.1)
       debug: 4.3.4


### PR DESCRIPTION
wait for the patch release of ts-client (https://github.com/fluencelabs/deal/pull/440), then bump

# QA
- [x] on CC detail page CUs are displayed